### PR TITLE
Enlarge mathjax fonts

### DIFF
--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -96,6 +96,7 @@
 
   {# Keep modernizr in head - http://modernizr.com/docs/#installing #}
   <script src="{{ pathto('_static/js/modernizr.min.js', 1) }}"></script>
+  {% include "mathjax_config.html" %}
 
   {% include "fonts.html" %}
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.2/css/all.css"

--- a/pytorch_sphinx_theme/mathjax_config.html
+++ b/pytorch_sphinx_theme/mathjax_config.html
@@ -1,0 +1,8 @@
+<script>
+    MathJax = {
+        chtml: {
+            scale: 1,
+            minScale: 1,
+        }
+    }
+</script>


### PR DESCRIPTION
Fixed the font scale to 1 to avoid MathJax's improper font size adaptation.