### PR TITLE
[Fix] Fix the missing files in the `pytorch_sphinx_theme` package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
         '*.html',
         'static/css/*.css',
         'static/js/*.js',
-        'static/fonts/*.*',
+        'static/js/*/*.js',
+        'static/fonts/*/*.*',
         'static/images/*.*',
         'theme_variables.jinja'
     ]},


### PR DESCRIPTION
As the title.

The `pytorch_sphinx_theme` package doesn't have some essential files because of the file match rules. This PR fixed it.